### PR TITLE
Correct page dimmer, tab switch, progress label and popup heart icon positons

### DIFF
--- a/content/partials/examples/dimmer.slim
+++ b/content/partials/examples/dimmer.slim
@@ -52,3 +52,12 @@
   .ui.page.button
     i.plus.icon
     |  Page Dimmer
+
+.ui.demo.page.dimmer
+  .content
+    .center
+      h1.ui.inverted.icon.header
+        i.mail.icon
+        | Dimmer Message
+        .sub.header
+          | Dimmer sub-header

--- a/content/partials/examples/progress.slim
+++ b/content/partials/examples/progress.slim
@@ -2,30 +2,14 @@
   .bar
     .progress
   .label
-    | Uploading Files
-<div class="ui basic demo progress active" data-percent="84">
-  <div class="bar" style="transition-duration: 300ms; width: 84%;">
-    <div class="progress"></div>
-  </div>
-  <div class="label">84% Complete</div>
-</div>
-<div class="ui basic demo progress active" data-percent="17">
-  <div class="bar" style="transition-duration: 300ms; width: 17%;">
-    <div class="progress">17%</div>
-  </div>
-  <div class="label">0% Complete</div>
-</div>
 .ui.indicating.demo.progress
   .bar
   .label
-    | Funding
 .ui.teal.file.demo.progress[data-value="6" data-total="20"]
   .bar
-    .progress
   .label
 .ui.top.attached.indicating.demo.progress
   .bar
 .ui.attached.segment
-
 .ui.bottom.attached.demo.progress
   .bar

--- a/content/static/javascripts/default.js
+++ b/content/static/javascripts/default.js
@@ -1,5 +1,5 @@
 $(document).ready(function() {
   // put your code here.
   $('.ui.dropdown').dropdown({on: 'hover'});
-  $('.ui.progress').progress();
+//$('.ui.progress').progress();
 });

--- a/content/static/kitchen-sink/javascripts/kitchen-sink.js
+++ b/content/static/kitchen-sink/javascripts/kitchen-sink.js
@@ -61,7 +61,7 @@ $(document)
         ;
       },
       page: function() {
-        $('body > .demo.page.dimmer')
+        $('.demo.page.dimmer')
           .dimmer('show')
         ;
       }

--- a/content/static/kitchen-sink/javascripts/kitchen-sink.js
+++ b/content/static/kitchen-sink/javascripts/kitchen-sink.js
@@ -547,7 +547,7 @@ $(document)
     // tab
     $('.tab.demo .menu .item')
       .tab({
-        history: true,
+     // history: true,
         context: $('.tab.demo')
       })
     ;

--- a/content/static/kitchen-sink/stylesheets/kitchen-sink.css
+++ b/content/static/kitchen-sink/stylesheets/kitchen-sink.css
@@ -68,3 +68,62 @@ h4 + .dimmer.demo {
 .transition.demo .ui.hidden.image {
   display: inline-block !important;
 }
+
+/* Popup, 8 heart icons in square */
+.position.no.example .segment {
+  width: 250px;
+  height: 250px;
+}
+
+.position.example .icon {
+  position: absolute;
+  margin: 0em;
+  width: auto;
+  font-size: 1.5em;
+  height: auto;
+  padding: 0.5em !important;
+}
+
+.position.no.example .segment .icon:nth-of-type(1) {
+  top: 0em;
+  left: 0em;
+}
+
+.position.no.example .segment .icon:nth-of-type(2) {
+  top: 0em;
+  left: 50%;
+  margin-left: -1em;
+}
+
+.position.no.example .segment .icon:nth-of-type(3) {
+  top: 0em;
+  right: 0em;
+}
+
+.position.no.example .segment .icon:nth-of-type(4) {
+  top: 50%;
+  right: 0em;
+  margin-top: -1em;
+}
+
+.position.no.example .segment .icon:nth-of-type(5) {
+  bottom: 0em;
+  right: 0em;
+}
+
+.position.no.example .segment .icon:nth-of-type(6) {
+  bottom: 0em;
+  left: 50%;
+  margin-left: -1em;
+}
+
+.position.no.example .segment .icon:nth-of-type(7) {
+  bottom: 0em;
+  left: 0em;
+}
+
+.position.no.example .segment .icon:nth-of-type(8) {
+  top: 50%;
+  left: 0em;
+  margin-top: -1em;
+}


### PR DESCRIPTION
Description:
- Page dimmer: add page dimmer HTML and correct selector
- Tab switch: comment out line "history: true"
- Progress bar and label: modify progress.slim and put kitchen-sink.js after default.js
- Popup 8 heart icons: make the segment square and define absolute positions for icons

Problem for discussion:
- h4 header like "Accordion, Table", the font-size is small, and color is black.