### PR TITLE
Adjust padding for first and last item in menu.

### DIFF
--- a/content/static/stylesheets/default.sass
+++ b/content/static/stylesheets/default.sass
@@ -75,6 +75,13 @@ img
     width: 200px
     margin: 3rem 0 1rem
 
+nav.ui.menu .ui.container
+  > a.item:first-child
+    padding-left: 0
+
+  > .right.menu > a.item:last-child
+    padding-right: 0
+
 /* Styles for sremantic-ui elements
 .ui
   &.alternative.segment

--- a/layouts/menu.slim
+++ b/layouts/menu.slim
@@ -1,4 +1,4 @@
-nav.ui.borderless.menu lang='en'
+nav.ui.borderless.menu
   .ui.container
     a.item href="/"
       img src="/static/logo/gravatar/gravatar.svg"


### PR DESCRIPTION
The first item of top menu should have `padding-left: 0` and the last
item of top menu should have `padding-right: 0`

Compare:

![image](https://cloud.githubusercontent.com/assets/1164623/21137081/4fa8a7d0-c163-11e6-8487-1a10d9b679cb.png)

With: 

![image](https://cloud.githubusercontent.com/assets/1164623/21137088/5a750924-c163-11e6-860c-cd4374b66f7e.png)
