### PR TITLE
Make logo on landing page center aligned

### DIFF
--- a/content/static/stylesheets/default.sass
+++ b/content/static/stylesheets/default.sass
@@ -160,7 +160,7 @@ nav.ui.menu .ui.container
     .tab
       width: 827px
 
-  #content .vertical.segment .container
+  #content .vertical.segment:not(.center) .container
     width: 827px
     margin-left: calc((100% - 1127px)/2) !important
 
@@ -175,7 +175,7 @@ nav.ui.menu .ui.container
     .tab
       width: 732px
 
-  #content .vertical.segment .container
+  #content .vertical.segment:not(.center) .container
     width: 732px
     margin-left: calc((100% - 933px)/2) !important
 
@@ -190,7 +190,7 @@ nav.ui.menu .ui.container
     .tab
       width: 550px
 
-  #content .vertical.segment .container
+  #content .vertical.segment:not(.center) .container
     width: 550px
     margin-left: calc((100% - 723px)/2) !important
 


### PR DESCRIPTION
Exclude the container on landing page from CSS definitions on theme displaying page.