### PR TITLE
Remove code icon on pages other than /themes

### DIFF
--- a/content/static/javascripts/docs.js
+++ b/content/static/javascripts/docs.js
@@ -432,21 +432,23 @@ semantic.ready = function() {
     },
 
     createIcon: function() {
-      $example
-        .each(function(){
-          var
-            $insertPoint = $(this).is('.another')
-              ? $(this).children().eq(0)
-              : $(this).children().eq(1)
-          ;
-          $('<i/>')
-            .addClass('icon code')
-            .insertBefore( $insertPoint )
-          ;
-        })
-        .find('i.code')
-          .on('click', handler.createCode)
-      ;
+      if (window.location.pathname.startsWith('/themes')) {
+        $example
+          .each(function(){
+            var
+              $insertPoint = $(this).is('.another')
+                ? $(this).children().eq(0)
+                : $(this).children().eq(1)
+            ;
+            $('<i/>')
+              .addClass('icon code')
+              .insertBefore( $insertPoint )
+            ;
+          })
+          .find('i.code')
+            .on('click', handler.createCode)
+        ;
+      }
     },
 
     less: {


### PR DESCRIPTION
Logic: use a `if` condition statement to check whether current page is a theme displayging page, according to the URL.

Functions involved:
- window.location.pathname: get the path from root of current page
- startsWith(): whether a string starts with a specific string
- includes(): whether a string includes a specific string(not applied, but still good)